### PR TITLE
Threaded search

### DIFF
--- a/curator.py
+++ b/curator.py
@@ -12,6 +12,9 @@ from PIL import Image, ImageTk  # used to handle images
 from tkinter import END, Frame, messagebox, Tk, TOP, BOTTOM, LEFT, RIGHT, BOTH, HORIZONTAL, SUNKEN, X, Y, BooleanVar, DoubleVar, IntVar, StringVar
 from tkinter.ttk import Button, Checkbutton, Entry, Frame, Label, Panedwindow, Scale, Spinbox, Style, Treeview # this overrides older controls in tkinter with newer tkk versions
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
+import queue
 
 DB_PATH = "curator.db"
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
@@ -106,7 +109,13 @@ class Query:
         self._parameters = {}
         self._museum = museum
         self.setParameter("hasImage", "true")
+        self.objectSet = []
         self.resultSet = []
+        self.state = 'new'
+        self._objectsLock = threading.Lock()
+        self._resultSetLock = threading.Lock()
+        self.idQueue = queue.Queue()
+        self.artObjectQueue = queue.Queue()
 
     def setParameter(self, parameterName, parameterValue):
         logging.debug("Setting Paramater " + parameterName + ":" + parameterValue)
@@ -114,6 +123,61 @@ class Query:
 
     def unsetParameter(self, parameterName):
         del self._parameters[parameterName]
+
+
+    def _fetchObjectIds(self):
+        self.objectSet = []
+        queryPayload = {}
+        queryHeaders= {}
+        q = self._museum.getSearchUrlBase()
+        q = q + urlencode(self._parameters)
+        logging.debug(q)
+        response = requests.request("GET", q, headers=queryHeaders, data = queryPayload)
+        jsonResponse = response.json()
+        logging.debug("Rest query reseived " + str(len(jsonResponse)) + " matches")
+        logging.debug(str(jsonResponse))
+        if jsonResponse['objectIDs']:
+            for id in jsonResponse['objectIDs']:
+                #self.idQueue.put(id)
+                self.objectSet.append(id)
+        return len(self.objectSet)
+
+
+    def _fetchArtObject(self, id):
+        objectHeaders = {}
+        objectPayload = {}
+        objectResponse = requests.request(
+            "GET",
+            self._museum.getObjectUrlBase()+str(id),
+            headers=objectHeaders,
+            data=objectPayload
+            )
+        objectJsonResponse = objectResponse.json()
+        artObject = ArtObject(
+            objectJsonResponse['objectID'],
+            objectJsonResponse['title'],
+            objectJsonResponse['artistDisplayName'],
+            objectJsonResponse['primaryImageSmall']
+        )
+        return(artObject)
+
+    def fetchArtObjects(self):
+        self.resultSet = []
+        self._fetchObjectIds()
+        with ThreadPoolExecutor() as executor:
+            #future = [executor.submit(self._fetchArtObject, id) for id in self.idQueue]
+            futures = [executor.submit(self._fetchArtObject, id) for id in self.objectSet]
+        for f in futures:
+            self.resultSet.append(f.result())
+        return self.resultSet
+        
+
+    def threadedQuery(self):
+        self.resultSet = []
+        self.fetchObjectIds()
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future = executor.submit(self.fetchDetails)
+            logging.debug('Number of Ids retrieved: ', future.result())
 
     def runQuery(self):
         resultSet = []

--- a/curator.py
+++ b/curator.py
@@ -126,6 +126,7 @@ class Query:
 
 
     def _fetchObjectIds(self):
+        logging.debug('_fetchObjectIds started')
         self.objectSet = []
         queryPayload = {}
         queryHeaders= {}
@@ -144,6 +145,7 @@ class Query:
 
 
     def _fetchArtObject(self, id):
+        logging.debug('_fetchArtObject started')
         objectHeaders = {}
         objectPayload = {}
         objectResponse = requests.request(
@@ -162,6 +164,7 @@ class Query:
         return(artObject)
 
     def fetchArtObjects(self):
+        logging.debug('fetArtObjects starting')
         self.resultSet = []
         self._fetchObjectIds()
         with ThreadPoolExecutor() as executor:
@@ -169,6 +172,13 @@ class Query:
             futures = [executor.submit(self._fetchArtObject, id) for id in self.objectSet]
         for f in futures:
             self.resultSet.append(f.result())
+        finishedToken = ArtObject(
+            'done',
+            'done',
+            'done',
+            'done'
+        )
+        self.resultSet.append(finishedToken)
         return self.resultSet
         
 

--- a/curator.py
+++ b/curator.py
@@ -11,13 +11,10 @@ from PIL import Image, ImageTk  # used to handle images
 #GUI
 from tkinter import END, Frame, messagebox, Tk, TOP, BOTTOM, LEFT, RIGHT, BOTH, HORIZONTAL, SUNKEN, X, Y, BooleanVar, DoubleVar, IntVar, StringVar
 from tkinter.ttk import Button, Checkbutton, Entry, Frame, Label, Panedwindow, Scale, Spinbox, Style, Treeview # this overrides older controls in tkinter with newer tkk versions
-
-import threading
 from concurrent.futures import ThreadPoolExecutor
-import queue
 
 DB_PATH = "curator.db"
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
 class User:
     def __init__(self, name):
@@ -112,10 +109,6 @@ class Query:
         self.objectSet = []
         self.resultSet = []
         self.state = 'new'
-        self._objectsLock = threading.Lock()
-        self._resultSetLock = threading.Lock()
-        self.idQueue = queue.Queue()
-        self.artObjectQueue = queue.Queue()
 
     def setParameter(self, parameterName, parameterValue):
         logging.debug("Setting Paramater " + parameterName + ":" + parameterValue)
@@ -139,7 +132,6 @@ class Query:
         logging.debug(str(jsonResponse))
         if jsonResponse['objectIDs']:
             for id in jsonResponse['objectIDs']:
-                #self.idQueue.put(id)
                 self.objectSet.append(id)
         return len(self.objectSet)
 
@@ -168,7 +160,6 @@ class Query:
         self.resultSet = []
         self._fetchObjectIds()
         with ThreadPoolExecutor() as executor:
-            #future = [executor.submit(self._fetchArtObject, id) for id in self.idQueue]
             futures = [executor.submit(self._fetchArtObject, id) for id in self.objectSet]
         for f in futures:
             self.resultSet.append(f.result())

--- a/curatorApp.py
+++ b/curatorApp.py
@@ -13,7 +13,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 import queue
 
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
 
 class CuratorApp:
@@ -28,8 +28,6 @@ class CuratorApp:
         
         self.executor = ThreadPoolExecutor()
         self.artObjectQueue = queue.Queue()
-        self.treeLock = threading.Lock()
-        
         
         # Menu
         menubar = Menu(root)

--- a/curatorApp.py
+++ b/curatorApp.py
@@ -167,6 +167,9 @@ class CuratorApp:
             text='<image placeholder>'
         )
 
+        # Updates image to WildCat Logo before controls are displayed
+        self.displayLogo()
+
         # Place controls
         self.window.pack(fill=BOTH, expand=True)
         self.window.add(self.controlFrame, weight=1)
@@ -193,8 +196,11 @@ class CuratorApp:
         self.resultsTree.pack(fill=BOTH, expand=True)
         self.artObjectImage.pack(fill=BOTH, expand=True)
 
-    # Pass paramters from GUI to the Query object to build the query string
+
     def buildQuery(self):
+        '''
+        Pass paramters from GUI to the Query object to build the query string
+        '''
         # Example of rest call for object search:
         # https://collectionapi.metmuseum.org/public/collection/v1/search?title=true&classification=PaintingsdepartmentId=11&isOnView=true&hasImages=true&isHighlight=false$dateBegin=-2000&dateEnd=2021&q=%22The%20Laundress%22
         if self.isTitleSearchValue.get() == 1:
@@ -225,8 +231,20 @@ class CuratorApp:
         self.queryObject.setParameter("dateEnd", self.dateEndValue.get())
         self.queryObject.setParameter("q", self.query.get())
 
-    
+    def displayLogo(self):
+        '''
+        displayLogo(): load logo into artObjectImage control
+        '''
+        self.openedUrl = urlopen('https://www.csuchico.edu/style-guide/visual/_images/Chico-state-athletics-icon.png')
+        self.objectImage = io.BytesIO(self.openedUrl.read())
+        self.pilImage = Image.open(self.objectImage)
+        self.tkImage = ImageTk.PhotoImage(self.pilImage)
+        self.artObjectImage.config(image=self.tkImage)
+        
     def queueArtObjects(self):
+        '''
+        queueArtObjects(): loads images in queue objects result set into a queue
+        '''
         logging.debug('queueArtObjects thread running')
         resultSet = self.queryObject.fetchArtObjects()
         for artObject in resultSet:
@@ -235,6 +253,9 @@ class CuratorApp:
         logging.debug('queueArtObjects finished queueing Art Objects')
     
     def dequeueArtObjects(self):
+        '''
+        dequeueArtObjects: loads queued objects into TreeView contoller
+        '''
         logging.debug('dequeueArtObjects thread running')
         while True:
             artObject = self.artObjectQueue.get()
@@ -250,11 +271,14 @@ class CuratorApp:
                     artObject.imageUrl,
                     text=artObject.title
                 ))
+        self.executor.submit(self.displayLogo)
         self.progressbar.stop()
 
     
-    # Runs the rest query based on the paramters selected in GUI
     def runSearch(self):
+        '''
+        Runs the rest query based on the paramters selected in GUI
+        '''
         self.progressbar.start()
         # reset adapated from:
         # https://stackoverflow.com/questions/22812134/how-to-clear-an-entire-treeview-with-tkinter
@@ -265,30 +289,10 @@ class CuratorApp:
         self.executor.submit(self.dequeueArtObjects)
         
 
-    # Runs the rest query based on the paramters selected in GUI
-    # def runSearch(self):
-    #     self.progressbar.start()
-    #     # reset adapated from:
-    #     # https://stackoverflow.com/questions/22812134/how-to-clear-an-entire-treeview-with-tkinter
-    #     for i in self.resultsTree.get_children():
-    #         self.resultsTree.delete(i)
-    #     self.buildQuery()
-    #     resultSet = self.queryObject.fetchArtObjects()  # runQuery()
-    #     # Iterate through results, and display the image of the first object
-    #     for position, artObject in enumerate(resultSet):
-    #         if position == 0:
-    #             self.show(artObject)
-    #         self.resultsTree.insert(
-    #             '',
-    #             position,
-    #             artObject.imageUrl,
-    #             text=artObject.title
-    #         )
-    #         position += 1
-    #     self.progressbar.stop()
-
-    # Retrieve and display the image of the item selected in the tree
     def showByUrl(self, event):
+        '''
+        Retrieve and display the image of the item selected in the tree
+        '''
         for i in self.resultsTree.selection():
             logging.debug(i)
             self.openedUrl = urlopen(i)
@@ -303,8 +307,11 @@ class CuratorApp:
             )
             self.artObjectImage.pack(fill=BOTH, expand=True)
 
-    # Retrieve and display the image of the given ArtObject
+
     def show(self, artObject):
+        '''
+        Retrieve and display the image of the given ArtObject
+        '''
         # adapted from
         # https://www.daniweb.com/programming/software-development/code/493005/display-an-image-from-the-web-tkinter
         logging.debug("Retrieving image from " + str(artObject.getImageUrl()))

--- a/curatorApp.py
+++ b/curatorApp.py
@@ -224,7 +224,7 @@ class CuratorApp:
         for i in self.resultsTree.get_children():
             self.resultsTree.delete(i)
         self.buildQuery()
-        resultSet = self.queryObject.runQuery()
+        resultSet = self.queryObject.fetchArtObjects()  # runQuery()
         # Iterate through results, and display the image of the first object
         for position, artObject in enumerate(resultSet):
             if position == 0:


### PR DESCRIPTION
Added:
Curator.fetchArtObjects() for concurrent object retrieval using python threads
Curator._fetchObjectIds() for retrieval of ids matching search criteria
Curator._fetchArtObject(id) for retrieval of art object details
CuratorApp.displayLogo() to display WildCat logo in Image Frame
CuratorApp.queueArtObjects() to initialize pipeline from search result to tree view
CuratorApp.dequeueArtObject() loads each queued art object into tree view

Updated:
CuratorApp.runSearch() utilizes new queueArtObjects() and dequeueArtObjects() methods